### PR TITLE
Continue builtin_copy() even if the program encounters an inaccessible file

### DIFF
--- a/macosac.py
+++ b/macosac.py
@@ -435,7 +435,7 @@ def builtin_copy(outputdir, artifact_list, log_file, copy_symlinks=False):
         log_fp.close()
         return 0
     except (IOError, OSError, shutil.Error) as err:
-        sys.exit('Error has been occurred in builtin_copy(): {}'.format(err))
+        print('Error has been occurred in builtin_copy(): {}'.format(err))
 
 
 def copy_artifact_files(outputdir, artifact_list, use_builtincopy=False, source_path='/'):


### PR DESCRIPTION
I realized that macosac with rsync mode fails on Sequoia because Apple has replaced rsync with openrsync.
We can still utilize --use-builtincopy option, but it finishes unexpectedly if the target file list includes an inaccessible file. 

I suggest not using sys.exit() as a workaround.